### PR TITLE
Upgrade to scalafmt 0.5.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ task wrapper(type: Wrapper) {
 dependencies {
     compile gradleApi()
     compile 'org.codehaus.groovy:groovy-all:2.4.7'
-    compile 'com.geirsson:scalafmt_2.11:0.5.1'
+    compile 'com.geirsson:scalafmt_2.11:0.5.3'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile gradleTestKit()

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ task wrapper(type: Wrapper) {
 dependencies {
     compile gradleApi()
     compile 'org.codehaus.groovy:groovy-all:2.4.7'
-    compile 'com.geirsson:scalafmt_2.11:0.5.3'
+    compile 'com.geirsson:scalafmt-core_2.11:0.5.3'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile gradleTestKit()


### PR DESCRIPTION
Needed to uptake new properties such as 'continuationIndent.extendSite'