### PR TITLE
add support to format files and also fail if files the needed formatt…

### DIFF
--- a/src/main/groovy/cz/alenkacz/gradle/scalafmt/ScalafmtFormatAndFailOnMisformattedFilesTask.groovy
+++ b/src/main/groovy/cz/alenkacz/gradle/scalafmt/ScalafmtFormatAndFailOnMisformattedFilesTask.groovy
@@ -1,0 +1,10 @@
+package cz.alenkacz.gradle.scalafmt
+
+import org.gradle.api.tasks.TaskAction
+
+class ScalafmtFormatAndFailOnMisformattedFilesTask extends ScalafmtFormatBase {
+    @TaskAction
+    def format() {
+        runScalafmt(false, true)
+    }
+}

--- a/src/main/groovy/cz/alenkacz/gradle/scalafmt/ScalafmtFormatBase.groovy
+++ b/src/main/groovy/cz/alenkacz/gradle/scalafmt/ScalafmtFormatBase.groovy
@@ -10,7 +10,7 @@ class ScalafmtFormatBase extends DefaultTask {
 
     PluginExtension pluginExtension
 
-    def runScalafmt(boolean testOnly = false) {
+    def runScalafmt(boolean testOnly = false, boolean failOnMisformattedFiles = false) {
         if (project.plugins.withType(JavaBasePlugin).empty) {
             logger.info("Java or Scala gradle plugin not available in this project, nothing to format")
             return
@@ -24,12 +24,17 @@ class ScalafmtFormatBase extends DefaultTask {
                 if (contents != formattedContents.get()) {
                     misformattedFiles.add(f.absolutePath)
                 }
-            } else {
+            } else if (failOnMisformattedFiles) {
+                if (contents != formattedContents.get()) {
+                    misformattedFiles.add(f.absolutePath)
+                }
+                f.write(formattedContents.get())
+            }else {
                 f.write(formattedContents.get())
             }
         }
 
-        if (testOnly && !misformattedFiles.empty) {
+        if (!misformattedFiles.empty && (testOnly || failOnMisformattedFiles)) {
             throw new ScalafmtFormatException(misformattedFiles)
         }
     }

--- a/src/main/groovy/cz/alenkacz/gradle/scalafmt/ScalafmtPlugin.groovy
+++ b/src/main/groovy/cz/alenkacz/gradle/scalafmt/ScalafmtPlugin.groovy
@@ -13,6 +13,8 @@ class ScalafmtPlugin implements Plugin<Project> {
         scalafmtAll.description = "Formats all source sets using scalafmt."
         Task checkScalafmtAll = project.tasks.create('checkScalafmtAll')
         checkScalafmtAll.description = "Checks formatting of all source sets using scalafmt."
+        Task scalafmtAllAndFailOnMisformattedFiles = project.tasks.create('scalafmtAllAndFailOnMisformattedFiles')
+        scalafmtAllAndFailOnMisformattedFiles.description = "Formats all source sets using scalafmt but fails if any misformatted files were found"
         PluginExtension extension = project.extensions.create('scalafmt', PluginExtension)
         project.plugins.withType(JavaBasePlugin) {
             def jpc = project.convention.getPlugin(JavaPluginConvention)
@@ -28,8 +30,15 @@ class ScalafmtPlugin implements Plugin<Project> {
                     t.pluginExtension = extension
                     t.description = "Checks formatting of ${sourceSet.name} source set using scalafmt."
                 }
+
+                def failOnMisformattedFilesTask = project.tasks.create(sourceSet.getTaskName("formatAndFailOnMisformattedFiles", "scalafmt"), ScalafmtFormatAndFailOnMisformattedFilesTask).configure { Task t ->
+                    t.sourceSet = sourceSet
+                    t.pluginExtension = extension
+                    t.description = "Formats ${sourceSet.name} source set using scalafmt and fails if any misformatted files were found."
+                }
                 scalafmtAll.dependsOn task
                 checkScalafmtAll.dependsOn checkTask
+                scalafmtAllAndFailOnMisformattedFiles.dependsOn failOnMisformattedFilesTask
             }
         }
     }

--- a/src/test/groovy/cz/alenkacz/gradle/scalafmt/FormatAndFailOnMisformattedFilesTaskTest.groovy
+++ b/src/test/groovy/cz/alenkacz/gradle/scalafmt/FormatAndFailOnMisformattedFilesTaskTest.groovy
@@ -1,0 +1,50 @@
+package cz.alenkacz.gradle.scalafmt
+
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class FormatAndFailOnMisformattedFilesTaskTest extends Specification {
+    def "fail for badly formatted code"() {
+        given:
+        def testProject = ProjectMother.basicProject()
+        def project = ProjectBuilder.builder().withProjectDir(testProject.projectRoot).build()
+        project.plugins.apply 'scala'
+        project.plugins.apply 'scalafmt'
+
+        when:
+        project.tasks.formatAndFailOnMisformattedFilesScalafmt.format()
+
+        then:
+        thrown ScalafmtFormatException
+    }
+
+    def "not fail for correctly formatted code"() {
+        given:
+        def testProject = ProjectMother.basicProjectWithCorrectlyFormattedFile()
+        def project = ProjectBuilder.builder().withProjectDir(testProject.projectRoot).build()
+        project.plugins.apply 'scala'
+        project.plugins.apply 'scalafmt'
+
+        when:
+        project.tasks.formatAndFailOnMisformattedFilesScalafmt.format()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "ignore source files in test"() {
+        given:
+        def testProject = ProjectMother.basicProjectWithIncorrectTestFile()
+        def project = ProjectBuilder.builder().withProjectDir(testProject.projectRoot).build()
+
+        project.plugins.apply 'scalafmt'
+        project.plugins.apply 'scala'
+
+        when:
+        project.evaluate()
+        project.tasks.formatAndFailOnMisformattedFilesScalafmt.format()
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/src/test/groovy/cz/alenkacz/gradle/scalafmt/ScalafmtPluginTest.groovy
+++ b/src/test/groovy/cz/alenkacz/gradle/scalafmt/ScalafmtPluginTest.groovy
@@ -19,5 +19,7 @@ class ScalafmtPluginTest extends Specification {
         project.tasks.checkTestScalafmt instanceof ScalafmtCheckTask
         project.tasks.scalafmtAll instanceof Task
         project.tasks.checkScalafmtAll instanceof Task
+        project.tasks.formatAndFailOnMisformattedFilesTestScalafmt instanceof ScalafmtFormatAndFailOnMisformattedFilesTask
+        project.tasks.scalafmtAllAndFailOnMisformattedFiles instanceof Task
     }
 }


### PR DESCRIPTION
This PR is created to support a use case where the scalafmt is used as part of pre_commit git hook. In case files need formatting, currently the files are formatted but escape the commit and are marked as modified files AFTER the commit was pushed - causing the user to have to commit and push again.

This PR preserves existing behavior but allows users to fail on files that need formatting hence failing the commit and keep the git history - clean.