### PR TITLE
Improving performance for multi-module projects

### DIFF
--- a/src/main/groovy/cz/alenkacz/gradle/scalafmt/ScalafmtFormatBase.groovy
+++ b/src/main/groovy/cz/alenkacz/gradle/scalafmt/ScalafmtFormatBase.groovy
@@ -11,10 +11,10 @@ import org.scalafmt.interfaces.Scalafmt
 
 class ScalafmtFormatBase extends DefaultTask {
     SourceSet sourceSet
-    ClassLoader cl = this.class.getClassLoader()
+    static ClassLoader cl = ScalafmtFormatBase.class.getClassLoader()
     PluginExtension pluginExtension
 
-    def globalFormatter = Scalafmt.create(cl)
+    static def globalFormatter = Scalafmt.create(cl)
             .withRespectVersion(false)
             .withDefaultVersion("1.5.1")
 


### PR DESCRIPTION
We applied the plugin on a project with around 50 submodules and noticed a large difference in scalafmt check task performance compared to the sbt plugin - over 4 min in gradle vs around 30 seconds or less in sbt. I investigated the setup a bit and there is a difference in how the global formatter is created. Making it static improves the performance on our project to the level observed in sbt.