### PR TITLE
Remove unnecessary files from `@InputFiles`

### DIFF
--- a/src/main/groovy/cz/alenkacz/gradle/scalafmt/ScalafmtFormatBase.groovy
+++ b/src/main/groovy/cz/alenkacz/gradle/scalafmt/ScalafmtFormatBase.groovy
@@ -21,8 +21,8 @@ class ScalafmtFormatBase extends DefaultTask {
 
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
-    def getSourceSet() {
-        return sourceSet.allSource
+    def getSourceFiles() {
+        return sourceSet.allSource.filter { File f -> canBeFormatted(f) }
     }
 
     @OutputFile
@@ -40,7 +40,7 @@ class ScalafmtFormatBase extends DefaultTask {
 
         def formatter = globalFormatter.withMavenRepositories(*getRepositoriesUrls())
 
-        getSourceSet().filter { File f -> canBeFormatted(f) }.each { File f ->
+        getSourceFiles().each { File f ->
             String contents = f.text
             logger.debug("Formatting '$f'")
             try {


### PR DESCRIPTION
Motivation:

After upgrading Gradle 7, I can see the following warning for the
implicit dependency between `checkScalafmt` task and our resources
folder though they are not related each other.
```
Execution optimizations have been disabled for task ':scala_2.13:checkScalafmt' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/mnt/actions-runner/_work/armeria/armeria/scala/scala_2.13/gen-src/main/resources'.
  Reason: Task ':scala_2.13:checkScalafmt' uses this output of task ':scala_2.13:versionProperties' without declaring an explicit or
  implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer
  to docs.gradle.org/7.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```

Modifications:

- Use only formattable files as an `@InputFiles`

Result:

Clean up noisy warnings in Gradle 7